### PR TITLE
new scene interface. removed most raw pointers

### DIFF
--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -14,23 +14,23 @@ int main(int argc, char *argv[]) {
     }
     scene.config.pixel_sampling_num(2);
     scene.config.render_flag(Render::BVH);
-
-    Sphere &sphere = scene.sphere().at(0, 13.67f, -62.57f).radius(10);
-
-    scene.pointLight(-80, 120, -46.6f, 1, 1, 1);
-    scene.ambientLight(0.05, 0.05, 0.05);
-
     scene.configCamera(24.2, 29.3, 53.6, 0, 0, -1, 35, 35, 35, 1000, 1000);
+
+    // Sphere &sphere = scene.sphere().at(0, 13.67f, -62.57f).radius(10);
+    // scene.pointLight(-80, 120, -46.6f, 1, 1, 1);
+    // scene.ambientLight(0.05, 0.05, 0.05);
+
+    scene.add(Sphere().at(0, 13.67f, -62.57f).radius(10))
+         .add(PointLight().at(-80, 120, -46.6f).in(1, 1, 1))
+	     .add(AmbientLight().in(0.05, 0.05, 0.05));
 
     scene.render();
 
     scene.save("simple.bmp");
 
-    sphere.at(20, 13.67f, -62.57f);
-
-    scene.render();
-
-    scene.save("simple2.bmp");
+    //sphere.at(20, 13.67f, -62.57f);
+    //scene.render();
+    //scene.save("simple2.bmp");
 
     return 0;
 }

--- a/include/mmgl/core/camera.h
+++ b/include/mmgl/core/camera.h
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <functional>
+#include <memory>
 
 #include "mmgl/util/point.h"
 #include "mmgl/util/vector.h"
@@ -39,27 +40,27 @@ public:
 
     Ray project_pixel(float i, float j);
 
-    void render(const std::vector<Surface *> &objects, const std::vector<Light *> &lights,
-                const BVHNode *const parent, const SceneConfig &sceneConfig);
+    void render(const std::vector<std::unique_ptr<Surface>> &objects, const std::vector<std::unique_ptr<Light>> &lights,
+                const std::unique_ptr<BVHNode> &parent, const SceneConfig &sceneConfig);
 
     void render_partition(const size_t partition_id, const size_t partition_size,
-                          const std::vector<Surface *> &objects, const std::vector<Light *> &lights,
-                          const BVHNode *const parent, const SceneConfig &sceneConfig, const int sampling_num_pow2);
+                          const std::vector<std::unique_ptr<Surface>> &objects, const std::vector<std::unique_ptr<Light>> &lights,
+                          const std::unique_ptr<BVHNode> &parent, const SceneConfig &sceneConfig);
 
     // add this function for multithreading
-    Vector render_pixel(int x, int y, const std::vector<Surface *> &objects, const std::vector<Light *> &lights,
-                        const BVHNode *const parent, const SceneConfig &sceneConfig,
+    Vector render_pixel(int x, int y, const std::vector<std::unique_ptr<Surface>> &objects, const std::vector<std::unique_ptr<Light>> &lights,
+                        const std::unique_ptr<BVHNode> &parent, const SceneConfig &sceneConfig,
                         const std::function<float()> &rand_float);
 
-    Vector L(Ray &ray, int recursive_limit, const Surface *const object_id,
-             const std::vector<Surface *> &objects, const std::vector<Light *> &lights,
-             const BVHNode *const parent, const Render &flag, int s_sampling_nu,
+    Vector L(Ray &ray, int recursive_limit, const uintptr_t object_id,
+             const std::vector<std::unique_ptr<Surface>> &objects, const std::vector<std::unique_ptr<Light>> &lights,
+             const std::unique_ptr<BVHNode> &parent, const Render &flag, int s_sampling_nu,
              const std::function<float()> &rand_float);
 
     std::pair<bool, Vector> blinn_phong(const Ray &pri_ray, const Point &light_pt, const Vector &light_cl,
                                         const Intersection &intersection,
-                                        const Material &material, const std::vector<Surface *> &objects,
-                                        const BVHNode *const parent,
+                                        const Material &material, const std::vector<std::unique_ptr<Surface>> &objects,
+                                        const std::unique_ptr<BVHNode> &parent,
                                         const Render &flag);
 
     void writeRgba(const std::string &) const;

--- a/include/mmgl/core/scene.h
+++ b/include/mmgl/core/scene.h
@@ -6,8 +6,8 @@
 #ifndef RAYTRACER_SCENE_H
 #define RAYTRACER_SCENE_H
 
+#include <memory>
 #include <vector>
-#include <queue>
 
 #include "mmgl/util/common.h"
 #include "mmgl/surface/surface.h"
@@ -36,30 +36,36 @@ public:
 
     void save(const std::string &file_path) const;
 
-    Sphere &sphere(float x = .0f, float y = .0f, float z = .0f, float radius = .0f,
-                   const Material &material = Material{});
+    Scene &add(const Sphere &sphere);
+    Scene &add(const Triangle &triangle);
+    Scene &add(const PointLight &point_light);
+    Scene &add(const AreaLight &area_light);
+    Scene &add(const AmbientLight &ambient_light);
 
-    Triangle &triangle(float x1 = .0f, float y1 = .0f, float z1 = .0f,
-                       float x2 = .0f, float y2 = .0f, float z2 = .0f,
-                       float x3 = .0f, float y3 = .0f, float z3 = .0f,
-                       const Material &material = Material{});
+    // Sphere &sphere(float x = .0f, float y = .0f, float z = .0f, float radius = .0f,
+    //                const Material &material = Material{});
 
-    PointLight &pointLight(float x = .0f, float y = .0f, float z = .0f,
-                           float r = .0f, float g = .0f, float b = .0f);
+    // Triangle &triangle(float x1 = .0f, float y1 = .0f, float z1 = .0f,
+    //                    float x2 = .0f, float y2 = .0f, float z2 = .0f,
+    //                    float x3 = .0f, float y3 = .0f, float z3 = .0f,
+    //                    const Material &material = Material{});
 
-    AreaLight &areaLight(float x = .0f, float y = .0f, float z = .0f, float nx = .0f, float ny = .0f, float nz = .0f,
-                         float ux = .0f, float uy = .0f, float uz = .0f, float len = .0f, float r = .0f, float g = .0f,
-                         float b = .0f);
+    // PointLight &pointLight(float x = .0f, float y = .0f, float z = .0f,
+    //                        float r = .0f, float g = .0f, float b = .0f);
 
-    AmbientLight &ambientLight(float r = .0f, float g = .0f, float b = .0f);
+    // AreaLight &areaLight(float x = .0f, float y = .0f, float z = .0f, float nx = .0f, float ny = .0f, float nz = .0f,
+    //                      float ux = .0f, float uy = .0f, float uz = .0f, float len = .0f, float r = .0f, float g = .0f,
+    //                      float b = .0f);
+
+    // AmbientLight &ambientLight(float r = .0f, float g = .0f, float b = .0f);
 
     ~Scene();
 
     // public member field config for easy access
     SceneConfig config;
 private:
-    std::vector<Surface *> _surfaces;
-    std::vector<Light *> _lights;
+    std::vector<std::unique_ptr<Surface>> _surfaces;
+    std::vector<std::unique_ptr<Light>> _lights;
 
     Camera _camera;
 };  // class Scene

--- a/include/mmgl/light/ambientlight.h
+++ b/include/mmgl/light/ambientlight.h
@@ -13,9 +13,11 @@ namespace mmgl {
 
 class AmbientLight : public Light {
 public:
-    AmbientLight(float r, float g, float b) : Light{r, g, b} { }
+    AmbientLight(float r = 0, float g = 0, float b = 0) : Light{r, g, b} { }
 
     AmbientLight(const Vector &rgb) : Light{rgb} { }
+
+    AmbientLight(const AmbientLight &light) : Light{light.color()} { }
 
     AmbientLight &in(const Vector &color);
 

--- a/include/mmgl/light/arealight.h
+++ b/include/mmgl/light/arealight.h
@@ -27,6 +27,10 @@ public:
         init();
     }
 
+    AreaLight(const AreaLight &light) : Light(light.color()), _orig(light.orig()), _norm(light.norm()), _u(light.u()), _len(light.len()) {
+        init();
+    }
+
     std::vector<Point> sample(int sampling_num, const std::function<float()> &rand_float);
 
     AreaLight &in(const Vector &color);

--- a/include/mmgl/light/light.h
+++ b/include/mmgl/light/light.h
@@ -17,7 +17,7 @@ public:
 
     Light(const Vector &rgb) : _color{rgb} { }
 
-    virtual inline const Vector &color() const {
+    inline const Vector &color() const {
         return _color;
     }
 

--- a/include/mmgl/light/pointlight.h
+++ b/include/mmgl/light/pointlight.h
@@ -19,6 +19,8 @@ public:
 
     PointLight(const Point &point, const Vector &rgb) : Light{rgb}, _orig{point} { }
 
+    PointLight(const PointLight &light) : Light(light.color()), _orig{light.orig()} { }
+
 
     inline const Point &orig() const {
         return _orig;

--- a/include/mmgl/surface/intersection.h
+++ b/include/mmgl/surface/intersection.h
@@ -6,6 +6,9 @@
 #ifndef RAYTRACER_INTERSECTION_H
 #define RAYTRACER_INTERSECTION_H
 
+#include <memory>
+#include <cstdint>
+
 #include "mmgl/util/point.h"
 #include "mmgl/util/vector.h"
 
@@ -15,11 +18,11 @@ class Surface;
 
 class Intersection {
 public:
-    Intersection() : _t(0.0f), _point(), _normal(), _id(nullptr) { }
+    Intersection() : _t(0.0f), _point(), _normal(), _id(reinterpret_cast<uintptr_t>(nullptr)) { }
 
-    Intersection(float t, const Point &point, const Vector &normal, const Surface *const id) : _t(t), _point(point),
-                                                                                               _normal(normal),
-                                                                                               _id(id) { }
+    Intersection(float t, const Point &point, const Vector &normal, const uintptr_t id) : _t(t), _point(point),
+                                                                                          _normal(normal),
+                                                                                          _id(id) { }
 
     inline float t() const {
         return _t;
@@ -33,7 +36,7 @@ public:
         return _normal;
     }
 
-    inline const Surface *id() const {
+    inline uintptr_t id() const {
         return _id;
     }
 
@@ -41,7 +44,7 @@ private:
     float _t;
     Point _point;
     Vector _normal;
-    const Surface *_id;
+    uintptr_t _id;
 };
 
 }

--- a/include/mmgl/surface/sphere.h
+++ b/include/mmgl/surface/sphere.h
@@ -8,6 +8,7 @@
 
 
 #include <iostream>
+#include <memory>
 #include <sstream>
 
 #include "mmgl/surface/surface.h"
@@ -17,15 +18,17 @@ namespace mmgl {
 
 class Sphere : public Surface {
 public:
-    Sphere(float x = 0, float y = 0, float z = 0, float r = 0);
+    Sphere(float x = 0, float y = 0, float z = 0, float r = 0, const Material &material = Material{});
 
-    Sphere(const Point &origin, float radius);
+    Sphere(const Point &origin, float radius, const Material &material = Material{});
 
-    bool intersect(Ray &, const Render &) const;
+    Sphere(const Sphere &sphere);
 
-    std::string to_string() const;
+    virtual Sphere *clone() const {
+        return {new Sphere(*this)};
+    }
 
-    inline const Point &origin() const {
+    inline const Point origin() const {
         return _origin;
     }
 
@@ -40,6 +43,10 @@ public:
     Sphere &radius(float radius);
 
     Sphere &made_of(const Material &material);
+
+    bool intersect(Ray &, const Render &) const;
+
+    std::string to_string() const;
 
 private:
     void init() {

--- a/include/mmgl/surface/surface.h
+++ b/include/mmgl/surface/surface.h
@@ -6,8 +6,9 @@
 #ifndef RAYTRACER_SURFACE_H
 #define RAYTRACER_SURFACE_H
 
-#include <string>
 #include <iostream>
+#include <memory>
+#include <string>
 
 #include "mmgl/surface/material.h"
 #include "mmgl/surface/ray.h"
@@ -19,6 +20,8 @@ namespace mmgl {
 class Surface {
 public:
     virtual ~Surface() { }
+
+    virtual Surface *clone() const = 0;
 
     inline const Material &material() const {
         return _material;

--- a/include/mmgl/surface/triangle.h
+++ b/include/mmgl/surface/triangle.h
@@ -18,13 +18,20 @@ class Triangle : public Surface {
 public:
     Triangle(float x1 = 0, float y1 = 0, float z1 = 0,
              float x2 = 0, float y2 = 0, float z2 = 0,
-             float x3 = 0, float y3 = 0, float z3 = 0);
+             float x3 = 0, float y3 = 0, float z3 = 0,
+             const Material &material = Material{});
 
-    Triangle(const Point &p1, const Point &p2, const Point &p3);
+    Triangle(const Point &p1, const Point &p2, const Point &p3, const Material &material = Material{});
 
-    bool intersect(Ray &, const Render &) const;
+    Triangle(const Triangle &triangle);
 
-    std::string to_string() const;
+    virtual Triangle *clone() const {
+        return {new Triangle(*this)};
+    }
+
+    inline Point p1() const { return _p1; }
+    inline Point p2() const { return _p2; }
+    inline Point p3() const { return _p3; }
 
     Triangle &point_one(const Point &p1);
 
@@ -39,6 +46,10 @@ public:
     Triangle &point_three(float x, float y, float z);
 
     Triangle &made_of(const Material &material);
+
+    bool intersect(Ray &, const Render &) const;
+
+    std::string to_string() const;
 
 private:
     void init() {

--- a/src/mmgl/surface/sphere.cc
+++ b/src/mmgl/surface/sphere.cc
@@ -5,14 +5,23 @@
 
 #include "mmgl/surface/sphere.h"
 
+#include <cstdint>
+
 namespace mmgl {
 
-Sphere::Sphere(float x, float y, float z, float r) : _origin{x, y, z}, _radius{r} {
+Sphere::Sphere(float x, float y, float z, float r, const Material &material) : _origin{x, y, z}, _radius{r} {
     init();
+    this->material(material);
 }
 
-Sphere::Sphere(const Point &origin, float radius) : _origin{origin}, _radius{radius} {
+Sphere::Sphere(const Point &origin, float radius, const Material &material) : _origin{origin}, _radius{radius} {
     init();
+    this->material(material);
+}
+
+Sphere::Sphere(const Sphere &sphere) : _origin{sphere.origin()}, _radius{sphere.radius()} {
+    init();
+    this->material(sphere.material());
 }
 
 bool Sphere::intersect(Ray &ray, const Render &flag) const {
@@ -24,7 +33,7 @@ bool Sphere::intersect(Ray &ray, const Render &flag) const {
         if (ray.updatable(box_hit.second)) {
             Point inter_p = ray._origin + ray._dir * box_hit.second;
             Vector norm = box_normal(inter_p);
-            ray.intersection(Intersection(box_hit.second, inter_p, norm, this));
+            ray.intersection(Intersection(box_hit.second, inter_p, norm, reinterpret_cast<uintptr_t>(this)));
         }
         return true;
     }
@@ -55,7 +64,7 @@ bool Sphere::intersect(Ray &ray, const Render &flag) const {
             Point inter_p = ray._origin + ray._dir * t;
             Vector norm = inter_p - _origin;
             norm.normalize();
-            ray.intersection(Intersection(t, inter_p, norm, this));
+            ray.intersection(Intersection(t, inter_p, norm, reinterpret_cast<uintptr_t>(this)));
         }
         return true;
     } else {

--- a/src/mmgl/surface/triangle.cc
+++ b/src/mmgl/surface/triangle.cc
@@ -9,12 +9,20 @@ namespace mmgl {
 
 Triangle::Triangle(float x1, float y1, float z1,
                    float x2, float y2, float z2,
-                   float x3, float y3, float z3) : _p1{x1, y1, z1}, _p2{x2, y2, z2}, _p3{x3, y3, z3} {
+                   float x3, float y3, float z3,
+                   const Material &material) : _p1{x1, y1, z1}, _p2{x2, y2, z2}, _p3{x3, y3, z3} {
     init();
+    this->material(material);
 }
 
-Triangle::Triangle(const Point &p1, const Point &p2, const Point &p3) : _p1{p1}, _p2{p2}, _p3{p3} {
+Triangle::Triangle(const Point &p1, const Point &p2, const Point &p3, const Material &material) : _p1{p1}, _p2{p2}, _p3{p3} {
     init();
+    this->material(material);
+}
+
+Triangle::Triangle(const Triangle &triangle) : _p1{triangle.p1()}, _p2{triangle.p2()}, _p3{triangle.p3()} {
+    init();
+    this->material(triangle.material());
 }
 
 bool Triangle::intersect(Ray &ray, const Render &flag) const {
@@ -26,7 +34,7 @@ bool Triangle::intersect(Ray &ray, const Render &flag) const {
         if (ray.updatable(box_hit.second)) {
             Point inter_p = ray._origin + ray._dir * box_hit.second;
             Vector norm = box_normal(inter_p);
-            ray.intersection(Intersection(box_hit.second, inter_p, norm, this));
+            ray.intersection(Intersection(box_hit.second, inter_p, norm, reinterpret_cast<uintptr_t>(this)));
         }
         return true;
     }
@@ -66,7 +74,7 @@ bool Triangle::intersect(Ray &ray, const Render &flag) const {
     if (ray.updatable(t)) {
         // if we survive here, compute the intersection point
         Point inter_p = ray._origin + ray._dir * t;
-        ray.intersection(Intersection{t, inter_p, _norm, this});
+        ray.intersection(Intersection{t, inter_p, _norm, reinterpret_cast<uintptr_t>(this)});
     }
     return true;
 }


### PR DESCRIPTION
Hi, I've implemented some new interfaces for the scene class and the surface classes, so now we don't need the Sphere& syntax. Instead we can do things like this:

```
Sphere sphere;
sphere.at(10,20,30);
scene.add(sphere);
sphere.at(20,30,40);
scene.add(sphere);

```

Please see the examples/simple.cpp for more detail with the lights. What do you think of this interface style? I think this looks much cleaner than the old version. If you like it, we can be consistent with this style and write it in our documents.

I think we can do something similar for the scene.config and scene.configCamera, to make them more easy to use.

We only have add() for now, and don't have delete(). If time allows, we can implement that too. I think only using add() should suffice for most use cases.

Another thing in this branch is I tried to replace most raw pointers with unique_ptrs. Thus, we don't need to explicitly deallocate memory, and the code uses more modern c++ features.
The code currently works fine with one object (so it works fine with simple.cpp), but for multiple objects, it has a runtime error. The problem is in bvh_node.cc, the BVHNode::intersect fails to peform dynamic_cast (at line 60 and 61), which seems weird. Would you please take a look and see if you can solve the problem? I'll also try to fix it later today.
